### PR TITLE
Update catch_human_agent.py with updated dm_env_adaptor.py behavior

### DIFF
--- a/examples/catch_human_agent.py
+++ b/examples/catch_human_agent.py
@@ -125,7 +125,7 @@ def main(_):
         step_result = env.step(actions)
 
         board = step_result.observation[_OBSERVATION_BOARD]
-        reward = step_result.observation[_OBSERVATION_REWARD]
+        reward = step_result.reward
 
         _render_window(board, window_surface, reward)
 


### PR DESCRIPTION
An update to dm_env_adaptor.py (https://github.com/deepmind/dm_env_rpc/commit/7a06811544a8cb4ce3f460a2afa3bd4ed8e80a24#diff-2c755513ee4f5f32331e60c10ce8ef602679781e87629139b0ba03db85848ab0) changed the default behavior that this script relied upon. This script assumes the reward will be packed into the step_result.observation[_OBSERVATION_REWARD] as it was previously with dm_env_adaptor calls prior to the updated. 

I believe that the current behavior requires that if you want the reward to be included into the observation you have to send it as an argument to dm_env_adaptor.py for example:
``` 
env, world_name = dm_env_adaptor.create_and_join_world( ..., requested_observations=[_OBSERVATION_BOARD, _OBSERVATION_REWARD])
```
The other way to get the reward is to call it from step_result.reward itself.